### PR TITLE
[AI] Fix invalid CloudRun configuration

### DIFF
--- a/application/ai/api-template.service.yml
+++ b/application/ai/api-template.service.yml
@@ -8,7 +8,6 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "$CLOUDRUN_MIN_INSTANCES"
         autoscaling.knative.dev/maxScale: "$CLOUDRUN_MAX_INSTANCES"
-        run.googleapis.com/gpu-zonal-redundancy-disabled: "true"
     spec:
       serviceAccountName: "$GCP_SERVICE_ACCOUNT_EMAIL"
       containers:


### PR DESCRIPTION
Remove gpu redundancy setting, not supported when GPU is not requested.